### PR TITLE
docs: update robotops_msgs TraceHouse prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ROS2 message package for distributed tracing in the RobotOps platform.
 
 ## Overview
 
-This package defines custom message types used by `rmw_robotops` to emit trace events that the Robot Agent consumes. Part of the distributed tracing system (ROB-33).
+This package defines custom message types used by `rmw_robotops` to emit trace events that TraceHouse consumes. Part of the distributed tracing system (ROB-33).
 
 ## Messages
 
@@ -138,7 +138,7 @@ bloom-generate rosdebian --os-name ubuntu --os-version noble --ros-distro jazzy
 
 ### Version Policy
 
-**Major versions** move in lockstep across the RobotOps ecosystem (`robotops_config`, `robotops_msgs`, `rmw_robotops`, `robot_agent`). When any component introduces a breaking change, all components bump to the next major version together.
+**Major versions** move in lockstep across the RobotOps ecosystem (`robotops_config`, `robotops_msgs`, `rmw_robotops`, TraceHouse). When any component introduces a breaking change, all components bump to the next major version together.
 
 **Minor and patch versions** evolve independently between major version boundaries. Backward compatibility is maintained for all minor and patch releases within the same major version.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -90,7 +90,7 @@ sudo apt update
 sudo apt install ros-jazzy-robotops-msgs
 ```
 
-## Rust SDK (for robot_agent and other Rust consumers)
+## Rust SDK (for TraceHouse and other Rust consumers)
 
 The `robotops-msgs` Rust crate provides native Rust bindings for all message types.
 


### PR DESCRIPTION
## Summary\n- Updated README wording to TraceHouse\n- Updated installation docs wording to TraceHouse\n- Kept package/message identifiers unchanged\n\n## Verification\n- git diff --check\n- Targeted search found no remaining user-facing robot_agent / robot-agent / robot agent / Robot Agent references in README.md or docs/INSTALLATION.md\n\nRefs ROB-219