### PR TITLE
Reword Canopy instructions in robotops_msgs/CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,31 +1,7 @@
-## Canopy — Knowledge Graph
+## Robot Ops project context
 
-The org-wide knowledge graph is at `RobotOpsInc/canopy` (`vault/`). This repo is
-documented at `vault/projects/robotops-msgs/`.
-
-The vault slug is the repo name lowercased with underscores replaced by hyphens
-(e.g. `robot_agent` → `robot-agent`, `web_app` → `web-app`).
-
-### Read Canopy before…
-
-* Making an architectural decision — check `vault/decisions/` and
-  `vault/projects/robotops-msgs/decisions/`
-* Touching a shared interface (protos, RMW API, config schema) — read the relevant
-  project pages to understand what downstream repos depend on
-* Investigating a regression that might be a known incident — check `vault/incidents/`
-
-### Leave a raw note when…
-
-When something notable happens — a decision is made, a public interface changes, a
-non-obvious bug is fixed, a constraint is discovered — create a file at:
-
-`vault/_raw/robotops-msgs-YYYY-MM-DD-<short-slug>.md`
-
-in the `RobotOpsInc/canopy` repo and open a PR against `main`. Keep it factual: what
-changed, why, any cross-repo implications. Especially for anything architectural or a
-new feature, describe in detail. You can use illustrations, links, text — the ingestion
-pipeline is very flexible. The canopy ingest workflow handles everything from there.
-Do not write vault pages directly.
+Before making changes in this repo, cross-check the codebase and related docs so
+updates are safe and consistent with existing Robot Ops behavior.
 
 
 # CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,30 @@
-## Robot Ops project context
+## Canopy — Internal Robot Ops guidance
 
-Before making changes in this repo, cross-check the codebase and related docs so
-updates are safe and consistent with existing Robot Ops behavior.
+The org-wide knowledge graph is at `RobotOpsInc/canopy` (`vault/`). This repo is
+documented at `vault/projects/robotops-msgs/`.
 
+This guidance is for internal Robot Ops developers only. Use it to keep changes
+safe and consistent with the existing codebase and related docs.
+
+The vault slug is the repo name lowercased with underscores replaced by hyphens
+(e.g. `robotops_msgs` → `robotops-msgs`).
+
+### Read Canopy before…
+
+* Making a change that affects shared message definitions or downstream consumers
+* Investigating a regression that might already be documented in `vault/incidents/`
+* Making an architectural or cross-repo decision — check `vault/decisions/` and related project notes
+
+### Leave a raw note when…
+
+When something notable happens — a decision is made, a public interface changes, a
+non-obvious bug is fixed, or a constraint is discovered — create a file at:
+
+`vault/_raw/robotops-msgs-YYYY-MM-DD-<short-slug>.md`
+
+in the `RobotOpsInc/canopy` repo and open a PR against `main`. Keep it factual:
+what changed, why, and any cross-repo implications. Do not write vault pages
+ directly.
 
 # CLAUDE.md
 


### PR DESCRIPTION
Reword the top-of-file Robot Ops guidance in CLAUDE.md to remove the Canopy knowledge-graph framing and emphasize cross-checking the codebase and related docs for safety and consistency.

Linear: ROB-229
