### PR TITLE
docs: add generative AI contribution policy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.5.3 (2026-05-29)
+-------------------
+
+* Added generative AI contribution policy documentation.
+
 0.5.2 (2026-02-05)
 -------------------
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ROS2 message package (`robotops_msgs`) for distributed tracing in RobotOps. Defines custom message types used by `rmw_robotops` to emit trace events that the Robot Agent consumes. Part of a larger observability system (ROB-33 epic).
 
+## AI Contribution Policy
+
+This repository follows Robot Ops' generative AI contributions policy. When you generate substantial portions of code, documentation, or other content, remind the developer to disclose this in the commit message and pull request description before submitting. Do not submit or stage commits on the developer's behalf without confirming they have reviewed the output and are taking ownership of it. The developer — not the AI tool — is the contributor of record.
+
 ## Development (Container-based)
 
 ROS2 Jazzy has no native macOS support. All development uses Docker:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to robotops_msgs
+
+Thanks for your interest in contributing to `robotops_msgs`!
+
+Please open issues or pull requests on the project repository. Keep changes focused, update documentation when behavior changes, and run the relevant build or verification commands from the Docker-based development environment described in [README.md](README.md).
+
+## Use of Generative AI Tools
+
+Robot Ops permits contributions — code, documentation, and other content — that are produced in whole or in part using generative AI tools (e.g. GitHub Copilot, Claude, Cursor, ChatGPT). However, any use of such tools must be disclosed at the time of contribution, recorded in the commit message and pull request description. Contributors are responsible for reviewing, testing, and taking full ownership of all submitted content regardless of how it was produced — AI-generated output should receive the same (or greater) scrutiny as hand-written code, including checks for correctness, security, and intellectual property issues. This policy is aligned with the [OSRF Generative AI Contributions Policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) (May 2025).
+
+**Commit message disclosure format:**
+
+```text
+Fix race condition in topic subscriber lifecycle management
+
+Resolves an issue where subscribers were not correctly unregistered
+on node shutdown under high message frequency. Adds a guard to the
+teardown sequence and extends the relevant unit tests.
+
+Closes #187.
+
+Generated-by: Claude (Anthropic, claude-sonnet-4-5, May 2025)
+```
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache 2.0 license.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ Releases are triggered manually via GitHub Actions:
 - **Production**: Run "Release" workflow from `main` branch
 - **Development**: Run "Release Development" workflow from `development` branch
 
+## Contributing
+
+Robot Ops welcomes contributions from the community. We permit the use of generative AI tools in contributions, with mandatory disclosure and contributor accountability. See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
+
 ## License
 
 Apache-2.0

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robotops_msgs</name>
-  <version>0.5.2</version>
+  <version>0.5.3</version>
   <description>ROS2 message definitions for RobotOps distributed tracing</description>
   <maintainer email="support@robotops.dev">RobotOps Team</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md with Robot Ops generative AI disclosure policy and example commit trailer
- add README pointer to the policy
- add CLAUDE.md AI contribution instructions for coding assistants

## Verification
- git diff --check
- grep -R "Use of Generative AI Tools\|AI Contribution Policy\|generative AI tools" -n CONTRIBUTING.md README.md CLAUDE.md

Related to ROB-264.

Generated-by: OpenAI (GPT-5.1 Codex, May 2026)