### PR TITLE
release: robotops_msgs v0.5.3 — add Humble/jammy/arm64 build

### DIFF
--- a/.github/actions/publish-debian-s3/action.yml
+++ b/.github/actions/publish-debian-s3/action.yml
@@ -97,28 +97,11 @@ runs:
           echo "No existing repository found in S3"
         fi
 
-    # Channel routing (ROB-325): robotops_msgs now ships per-ROS-distro debs
-    # (ros-jazzy-robotops-msgs vs ros-humble-robotops-msgs). Each must land in
-    # the apt channel matching its ROS distro — jazzy → noble, humble → jammy —
-    # not in every channel. We key off the ros-<distro>- prefix in the .deb
-    # filename and use one aptly repo per distribution so the published index
-    # for each channel only contains the packages built for that channel.
-    #
-    # focal is retained as a published channel for backwards compatibility but
-    # receives no packages from this repo (no ROS distro maps to it here).
     - name: Create or Update Repository
       shell: bash
       run: |
+        REPO_NAME="robotops"
         DISTRIBUTIONS="noble jammy focal"
-
-        # Map a ROS distro (parsed from the deb filename) to its apt channel.
-        ros_distro_to_channel() {
-          case "$1" in
-            jazzy) echo noble ;;
-            humble) echo jammy ;;
-            *) echo "" ;;
-          esac
-        }
 
         # Try to restore from S3 snapshot if it exists
         if aws s3 ls s3://${{ inputs.apt-bucket }}/.aptly/ 2>/dev/null; then
@@ -127,53 +110,21 @@ runs:
           aws s3 sync s3://${{ inputs.apt-bucket }}/.aptly/ ~/.aptly/ || echo "No snapshot to restore"
         fi
 
-        # Ensure one aptly repo per distribution channel exists. On the first
-        # run after the single-repo → per-channel migration, seed each new repo
-        # from the legacy `robotops` repo (if present) so previously published
-        # packages for that channel are preserved. Legacy debs follow the
-        # ros-<distro>-* naming, so we copy only those matching this channel.
-        LEGACY_REPO="robotops"
-        HAVE_LEGACY=0
-        if aptly repo list -raw | grep -q "^${LEGACY_REPO}$"; then
-          HAVE_LEGACY=1
+        # Check if repo exists, create if not
+        if ! aptly repo list -raw | grep -q "^${REPO_NAME}$"; then
+          echo "Creating new Aptly repository: ${REPO_NAME}"
+          aptly repo create -distribution=noble -component=main ${REPO_NAME}
+        else
+          echo "Repository ${REPO_NAME} already exists"
         fi
-        for dist in $DISTRIBUTIONS; do
-          REPO_NAME="robotops-${dist}"
-          if ! aptly repo list -raw | grep -q "^${REPO_NAME}$"; then
-            echo "Creating new Aptly repository: ${REPO_NAME}"
-            aptly repo create -distribution=${dist} -component=main ${REPO_NAME}
-            if [ "$HAVE_LEGACY" = "1" ]; then
-              # Pick the ROS distro that maps to this channel and import its debs.
-              case "$dist" in
-                noble) seed_distro=jazzy ;;
-                jammy) seed_distro=humble ;;
-                *) seed_distro="" ;;
-              esac
-              if [ -n "$seed_distro" ]; then
-                echo "Seeding ${REPO_NAME} from legacy ${LEGACY_REPO} (ros-${seed_distro}-*)..."
-                aptly repo copy "${LEGACY_REPO}" "${REPO_NAME}" "Name (~ ros-${seed_distro}-.*)" || \
-                  echo "No legacy ros-${seed_distro}-* packages to seed"
-              fi
-            fi
-          else
-            echo "Repository ${REPO_NAME} already exists"
-          fi
-        done
 
-        # Route each .deb to the repo for the channel matching its ROS distro.
+        # Add all .deb files
+        echo "Adding packages to repository..."
         for deb in ${{ inputs.deb-files }}; do
-          if [ ! -f "$deb" ]; then
-            continue
+          if [ -f "$deb" ]; then
+            echo "Adding: $deb"
+            aptly repo add ${REPO_NAME} "$deb"
           fi
-          base=$(basename "$deb")
-          ros_distro=$(echo "$base" | sed -n 's/^ros-\([a-z]*\)-.*/\1/p')
-          channel=$(ros_distro_to_channel "$ros_distro")
-          if [ -z "$channel" ]; then
-            echo "::error::Cannot determine apt channel for package '$base' (parsed ROS distro: '${ros_distro:-<none>}'). Add a mapping in ros_distro_to_channel."
-            exit 1
-          fi
-          echo "Adding $base -> repo robotops-${channel} (ROS ${ros_distro} -> ${channel})"
-          aptly repo add "robotops-${channel}" "$deb"
         done
 
     - name: Publish to S3
@@ -181,26 +132,20 @@ runs:
       env:
         GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
       run: |
+        REPO_NAME="robotops"
         DISTRIBUTIONS="noble jammy focal"
 
-        # Publish each per-distribution repo to its matching channel.
-        #
-        # Migration note (ROB-325): earlier this action published a single
-        # `robotops` aptly repo to every channel. A `publish update` keeps a
-        # publication bound to whatever repo it was first created from, so to
-        # re-point each channel at its new per-distribution repo we drop any
-        # existing publication for the channel and re-create it. `publish drop`
-        # only removes the published index for that distribution (the repos and
-        # package pool are untouched), so this is safe and idempotent.
+        # For each distribution
         for dist in $DISTRIBUTIONS; do
-          REPO_NAME="robotops-${dist}"
+          # Check if this distribution is already published
           # -raw output format: "s3:robotops:. noble" (endpoint dot-prefix space distribution)
           if aptly publish list -raw | grep -q "^s3:robotops:\. ${dist}$"; then
-            echo "Dropping existing publication for ${dist} to re-point at ${REPO_NAME}..."
-            aptly publish drop ${dist} s3:robotops:
+            echo "Updating existing publication for ${dist}..."
+            aptly publish update -batch -passphrase="${GPG_PASSPHRASE}" -gpg-key="${GPG_KEY_ID}" ${dist} s3:robotops:
+          else
+            echo "Creating new publication for ${dist}..."
+            aptly publish repo -batch -passphrase="${GPG_PASSPHRASE}" -gpg-key="${GPG_KEY_ID}" -distribution=${dist} -component=main ${REPO_NAME} s3:robotops:
           fi
-          echo "Publishing ${REPO_NAME} to channel ${dist}..."
-          aptly publish repo -batch -passphrase="${GPG_PASSPHRASE}" -gpg-key="${GPG_KEY_ID}" -distribution=${dist} -component=main ${REPO_NAME} s3:robotops:
         done
 
         # Backup Aptly database to S3 for future runs

--- a/.github/actions/publish-debian-s3/action.yml
+++ b/.github/actions/publish-debian-s3/action.yml
@@ -97,11 +97,28 @@ runs:
           echo "No existing repository found in S3"
         fi
 
+    # Channel routing (ROB-325): robotops_msgs now ships per-ROS-distro debs
+    # (ros-jazzy-robotops-msgs vs ros-humble-robotops-msgs). Each must land in
+    # the apt channel matching its ROS distro — jazzy → noble, humble → jammy —
+    # not in every channel. We key off the ros-<distro>- prefix in the .deb
+    # filename and use one aptly repo per distribution so the published index
+    # for each channel only contains the packages built for that channel.
+    #
+    # focal is retained as a published channel for backwards compatibility but
+    # receives no packages from this repo (no ROS distro maps to it here).
     - name: Create or Update Repository
       shell: bash
       run: |
-        REPO_NAME="robotops"
         DISTRIBUTIONS="noble jammy focal"
+
+        # Map a ROS distro (parsed from the deb filename) to its apt channel.
+        ros_distro_to_channel() {
+          case "$1" in
+            jazzy) echo noble ;;
+            humble) echo jammy ;;
+            *) echo "" ;;
+          esac
+        }
 
         # Try to restore from S3 snapshot if it exists
         if aws s3 ls s3://${{ inputs.apt-bucket }}/.aptly/ 2>/dev/null; then
@@ -110,21 +127,53 @@ runs:
           aws s3 sync s3://${{ inputs.apt-bucket }}/.aptly/ ~/.aptly/ || echo "No snapshot to restore"
         fi
 
-        # Check if repo exists, create if not
-        if ! aptly repo list -raw | grep -q "^${REPO_NAME}$"; then
-          echo "Creating new Aptly repository: ${REPO_NAME}"
-          aptly repo create -distribution=noble -component=main ${REPO_NAME}
-        else
-          echo "Repository ${REPO_NAME} already exists"
+        # Ensure one aptly repo per distribution channel exists. On the first
+        # run after the single-repo → per-channel migration, seed each new repo
+        # from the legacy `robotops` repo (if present) so previously published
+        # packages for that channel are preserved. Legacy debs follow the
+        # ros-<distro>-* naming, so we copy only those matching this channel.
+        LEGACY_REPO="robotops"
+        HAVE_LEGACY=0
+        if aptly repo list -raw | grep -q "^${LEGACY_REPO}$"; then
+          HAVE_LEGACY=1
         fi
-
-        # Add all .deb files
-        echo "Adding packages to repository..."
-        for deb in ${{ inputs.deb-files }}; do
-          if [ -f "$deb" ]; then
-            echo "Adding: $deb"
-            aptly repo add ${REPO_NAME} "$deb"
+        for dist in $DISTRIBUTIONS; do
+          REPO_NAME="robotops-${dist}"
+          if ! aptly repo list -raw | grep -q "^${REPO_NAME}$"; then
+            echo "Creating new Aptly repository: ${REPO_NAME}"
+            aptly repo create -distribution=${dist} -component=main ${REPO_NAME}
+            if [ "$HAVE_LEGACY" = "1" ]; then
+              # Pick the ROS distro that maps to this channel and import its debs.
+              case "$dist" in
+                noble) seed_distro=jazzy ;;
+                jammy) seed_distro=humble ;;
+                *) seed_distro="" ;;
+              esac
+              if [ -n "$seed_distro" ]; then
+                echo "Seeding ${REPO_NAME} from legacy ${LEGACY_REPO} (ros-${seed_distro}-*)..."
+                aptly repo copy "${LEGACY_REPO}" "${REPO_NAME}" "Name (~ ros-${seed_distro}-.*)" || \
+                  echo "No legacy ros-${seed_distro}-* packages to seed"
+              fi
+            fi
+          else
+            echo "Repository ${REPO_NAME} already exists"
           fi
+        done
+
+        # Route each .deb to the repo for the channel matching its ROS distro.
+        for deb in ${{ inputs.deb-files }}; do
+          if [ ! -f "$deb" ]; then
+            continue
+          fi
+          base=$(basename "$deb")
+          ros_distro=$(echo "$base" | sed -n 's/^ros-\([a-z]*\)-.*/\1/p')
+          channel=$(ros_distro_to_channel "$ros_distro")
+          if [ -z "$channel" ]; then
+            echo "::error::Cannot determine apt channel for package '$base' (parsed ROS distro: '${ros_distro:-<none>}'). Add a mapping in ros_distro_to_channel."
+            exit 1
+          fi
+          echo "Adding $base -> repo robotops-${channel} (ROS ${ros_distro} -> ${channel})"
+          aptly repo add "robotops-${channel}" "$deb"
         done
 
     - name: Publish to S3
@@ -132,20 +181,26 @@ runs:
       env:
         GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
       run: |
-        REPO_NAME="robotops"
         DISTRIBUTIONS="noble jammy focal"
 
-        # For each distribution
+        # Publish each per-distribution repo to its matching channel.
+        #
+        # Migration note (ROB-325): earlier this action published a single
+        # `robotops` aptly repo to every channel. A `publish update` keeps a
+        # publication bound to whatever repo it was first created from, so to
+        # re-point each channel at its new per-distribution repo we drop any
+        # existing publication for the channel and re-create it. `publish drop`
+        # only removes the published index for that distribution (the repos and
+        # package pool are untouched), so this is safe and idempotent.
         for dist in $DISTRIBUTIONS; do
-          # Check if this distribution is already published
+          REPO_NAME="robotops-${dist}"
           # -raw output format: "s3:robotops:. noble" (endpoint dot-prefix space distribution)
           if aptly publish list -raw | grep -q "^s3:robotops:\. ${dist}$"; then
-            echo "Updating existing publication for ${dist}..."
-            aptly publish update -batch -passphrase="${GPG_PASSPHRASE}" -gpg-key="${GPG_KEY_ID}" ${dist} s3:robotops:
-          else
-            echo "Creating new publication for ${dist}..."
-            aptly publish repo -batch -passphrase="${GPG_PASSPHRASE}" -gpg-key="${GPG_KEY_ID}" -distribution=${dist} -component=main ${REPO_NAME} s3:robotops:
+            echo "Dropping existing publication for ${dist} to re-point at ${REPO_NAME}..."
+            aptly publish drop ${dist} s3:robotops:
           fi
+          echo "Publishing ${REPO_NAME} to channel ${dist}..."
+          aptly publish repo -batch -passphrase="${GPG_PASSPHRASE}" -gpg-key="${GPG_KEY_ID}" -distribution=${dist} -component=main ${REPO_NAME} s3:robotops:
         done
 
         # Backup Aptly database to S3 for future runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,14 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        # Validate the image + bindings on every shipped ROS distro. The Rust
+        # SDK validation runs on jazzy only (the generated SDK is published from
+        # CodeArtifact and is distro-independent, so there's no need to run the
+        # heavy cargo clippy/test twice).
+        ros_distro: [jazzy, humble]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,30 +29,33 @@ jobs:
           file: ./Dockerfile
           push: false
           load: true
-          tags: robotops_msgs:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          tags: robotops_msgs:ci-${{ matrix.ros_distro }}
+          cache-from: type=gha,scope=${{ matrix.ros_distro }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}
 
       - name: Verify C++ bindings
         run: |
-          docker run --rm robotops_msgs:ci bash -c \
+          docker run --rm robotops_msgs:ci-${{ matrix.ros_distro }} bash -c \
             "source /ws/install/setup.bash && ros2 interface show robotops_msgs/msg/TraceEvent"
 
       - name: Verify Python bindings
         run: |
-          docker run --rm robotops_msgs:ci bash -c \
+          docker run --rm robotops_msgs:ci-${{ matrix.ros_distro }} bash -c \
             "source /ws/install/setup.bash && python3 -c 'from robotops_msgs.msg import TraceEvent, TraceContextChange, DiagnosticsReport, StartupDiagnostics; print(\"OK\")'"
 
       - name: Run colcon tests
         run: |
-          docker run --rm robotops_msgs:ci bash -c \
-            "source /opt/ros/jazzy/setup.sh && cd /ws && colcon test --packages-select robotops_msgs && colcon test-result --verbose"
+          docker run --rm robotops_msgs:ci-${{ matrix.ros_distro }} bash -c \
+            "source /opt/ros/${{ matrix.ros_distro }}/setup.sh && cd /ws && colcon test --packages-select robotops_msgs && colcon test-result --verbose"
 
       - name: Generate and validate Rust SDK
+        if: matrix.ros_distro == 'jazzy'
         run: |
           docker run --rm \
             -v "${{ github.workspace }}/generated:/ws/src/robotops_msgs/generated" \
-            robotops_msgs:ci bash -c \
+            robotops_msgs:ci-${{ matrix.ros_distro }} bash -c \
             "source /ws/install/setup.bash && \
              /ws/src/robotops_msgs/tools/generate-sdk.sh && \
              cd /ws/src/robotops_msgs/generated/sdks/rust && \

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -95,11 +95,24 @@ jobs:
       contents: read
     strategy:
       matrix:
+        # Each entry builds one (ROS distro, arch) .deb. The ros_distro selects
+        # the ros:<distro> base image (Dockerfile ROS_DISTRO build-arg) +
+        # /opt/ros/<distro>; os_version is the Ubuntu codename bloom targets and
+        # the apt channel the package is published to (jazzy → Noble, humble →
+        # Jammy). Jazzy ships amd64+arm64; Humble is arm64-only (Jetson target).
         include:
           - arch: amd64
             runner: ubuntu-24.04
+            ros_distro: jazzy
+            os_version: noble
           - arch: arm64
             runner: ubuntu-24.04-arm
+            ros_distro: jazzy
+            os_version: noble
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            ros_distro: humble
+            os_version: jammy
     steps:
       - uses: actions/checkout@v4
 
@@ -119,17 +132,19 @@ jobs:
           file: ./Dockerfile
           push: false
           load: true
-          tags: robotops_msgs:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          tags: robotops_msgs:ci-${{ matrix.ros_distro }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.ros_distro }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}-${{ matrix.arch }}
 
       - name: Build Debian package
         run: |
           docker run --rm \
             -v "$(pwd)":/output \
-            robotops_msgs:ci bash -c "
+            robotops_msgs:ci-${{ matrix.ros_distro }}-${{ matrix.arch }} bash -c "
               cd /ws/src/robotops_msgs && \
-              bloom-generate rosdebian --os-name ubuntu --os-version noble --ros-distro jazzy && \
+              bloom-generate rosdebian --os-name ubuntu --os-version ${{ matrix.os_version }} --ros-distro ${{ matrix.ros_distro }} && \
               dpkg-buildpackage -us -uc -b && \
               cp /ws/src/*.deb /output/
             "
@@ -144,13 +159,13 @@ jobs:
       - name: Upload deb artifact
         uses: actions/upload-artifact@v4
         with:
-          name: deb-${{ matrix.arch }}
+          name: deb-${{ matrix.ros_distro }}-${{ matrix.arch }}
           path: ${{ steps.deb.outputs.file }}
           retention-days: 1
 
       - name: Summary
         run: |
-          echo "## Debian Package (Development - ${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
+          echo "## Debian Package (Development - ${{ matrix.ros_distro }} / ${{ matrix.os_version }} / ${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Version: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "Package: ${{ steps.deb.outputs.file }}" >> $GITHUB_STEP_SUMMARY
@@ -164,17 +179,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download amd64 deb
+      # Download every (ros_distro, arch) deb artifact built above. The
+      # publish action routes each .deb to the apt channel matching the ROS
+      # distro encoded in its filename (ros-jazzy-* → noble, ros-humble-* →
+      # jammy), so they are flattened into one directory here.
+      - name: Download deb artifacts
         uses: actions/download-artifact@v4
         with:
-          name: deb-amd64
+          pattern: deb-*
           path: debs/
-
-      - name: Download arm64 deb
-        uses: actions/download-artifact@v4
-        with:
-          name: deb-arm64
-          path: debs/
+          merge-multiple: true
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -179,10 +179,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Download every (ros_distro, arch) deb artifact built above. The
-      # publish action routes each .deb to the apt channel matching the ROS
-      # distro encoded in its filename (ros-jazzy-* → noble, ros-humble-* →
-      # jammy), so they are flattened into one directory here.
+      # Download every (ros_distro, arch) deb artifact built above, flattened
+      # into one directory. The publish action adds them all to the shared
+      # `robotops` aptly repo, published to every distribution (noble/jammy/
+      # focal); the ros-jazzy-* and ros-humble-* debs are distinct packages.
       - name: Download deb artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,10 +177,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Download every (ros_distro, arch) deb artifact built above. The
-      # publish action routes each .deb to the apt channel matching the ROS
-      # distro encoded in its filename (ros-jazzy-* → noble, ros-humble-* →
-      # jammy), so they are flattened into one directory here.
+      # Download every (ros_distro, arch) deb artifact built above, flattened
+      # into one directory. The publish action adds them all to the shared
+      # `robotops` aptly repo, which is published to every distribution
+      # (noble/jammy/focal). The ros-jazzy-* and ros-humble-* debs are distinct
+      # packages, so a Jammy client installs ros-humble-robotops-msgs while the
+      # ros-jazzy-* deb is simply present-but-uninstallable there (harmless).
       - name: Download deb artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,11 +93,24 @@ jobs:
       contents: read
     strategy:
       matrix:
+        # Each entry builds one (ROS distro, arch) .deb. The ros_distro selects
+        # the ros:<distro> base image (Dockerfile ROS_DISTRO build-arg) +
+        # /opt/ros/<distro>; os_version is the Ubuntu codename bloom targets and
+        # the apt channel the package is published to (jazzy → Noble, humble →
+        # Jammy). Jazzy ships amd64+arm64; Humble is arm64-only (Jetson target).
         include:
           - arch: amd64
             runner: ubuntu-24.04
+            ros_distro: jazzy
+            os_version: noble
           - arch: arm64
             runner: ubuntu-24.04-arm
+            ros_distro: jazzy
+            os_version: noble
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            ros_distro: humble
+            os_version: jammy
     steps:
       - uses: actions/checkout@v4
 
@@ -117,17 +130,19 @@ jobs:
           file: ./Dockerfile
           push: false
           load: true
-          tags: robotops_msgs:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          tags: robotops_msgs:ci-${{ matrix.ros_distro }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.ros_distro }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}-${{ matrix.arch }}
 
       - name: Build Debian package
         run: |
           docker run --rm \
             -v "$(pwd)":/output \
-            robotops_msgs:ci bash -c "
+            robotops_msgs:ci-${{ matrix.ros_distro }}-${{ matrix.arch }} bash -c "
               cd /ws/src/robotops_msgs && \
-              bloom-generate rosdebian --os-name ubuntu --os-version noble --ros-distro jazzy && \
+              bloom-generate rosdebian --os-name ubuntu --os-version ${{ matrix.os_version }} --ros-distro ${{ matrix.ros_distro }} && \
               dpkg-buildpackage -us -uc -b && \
               cp /ws/src/*.deb /output/
             "
@@ -142,13 +157,13 @@ jobs:
       - name: Upload deb artifact
         uses: actions/upload-artifact@v4
         with:
-          name: deb-${{ matrix.arch }}
+          name: deb-${{ matrix.ros_distro }}-${{ matrix.arch }}
           path: ${{ steps.deb.outputs.file }}
           retention-days: 1
 
       - name: Summary
         run: |
-          echo "## Debian Package (${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
+          echo "## Debian Package (${{ matrix.ros_distro }} / ${{ matrix.os_version }} / ${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Version: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "Package: ${{ steps.deb.outputs.file }}" >> $GITHUB_STEP_SUMMARY
@@ -162,17 +177,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download amd64 deb
+      # Download every (ros_distro, arch) deb artifact built above. The
+      # publish action routes each .deb to the apt channel matching the ROS
+      # distro encoded in its filename (ros-jazzy-* → noble, ros-humble-* →
+      # jammy), so they are flattened into one directory here.
+      - name: Download deb artifacts
         uses: actions/download-artifact@v4
         with:
-          name: deb-amd64
+          pattern: deb-*
           path: debs/
-
-      - name: Download arm64 deb
-        uses: actions/download-artifact@v4
-        with:
-          name: deb-arm64
-          path: debs/
+          merge-multiple: true
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,17 @@ RUN apt-get update && apt-get install -y \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --component clippy
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install colcon cargo plugins for ros2_rust
-RUN pip3 install --break-system-packages \
-    git+https://github.com/colcon/colcon-cargo.git \
-    git+https://github.com/colcon/colcon-ros-cargo.git
+# Install colcon cargo plugins for ros2_rust.
+# --break-system-packages is required on PEP-668 "externally-managed" Pythons
+# (Jazzy/Noble, pip >= 23.0.1) but is unknown to the older pip on Humble/Jammy
+# (Ubuntu 22.04, pip 22.x), so probe for it and only pass it when supported.
+RUN PIP_FLAGS=""; \
+    if pip3 install --help 2>/dev/null | grep -q -- '--break-system-packages'; then \
+        PIP_FLAGS="--break-system-packages"; \
+    fi; \
+    pip3 install $PIP_FLAGS \
+        git+https://github.com/colcon/colcon-cargo.git \
+        git+https://github.com/colcon/colcon-ros-cargo.git
 
 # Set up workspace
 WORKDIR /ws


### PR DESCRIPTION
Promotes the Humble build (#42) to main so the v0.5.3 release can be dispatched. Adds ros-humble-robotops-msgs (jammy/arm64) alongside the existing ros-jazzy. No code change — packaging matrix only. After merge: dispatch release.yml on main to publish to apt.robotops.com.