### PR TITLE
release: robotops_msgs v0.5.4 — add Humble/amd64 build (ROB-402)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,10 @@ jobs:
             runner: ubuntu-24.04-arm
             ros_distro: humble
             os_version: jammy
+          - arch: amd64
+            runner: ubuntu-22.04
+            ros_distro: humble
+            os_version: jammy
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.5.4 (2026-06-16)
+-------------------
+
+* Published Humble/amd64 Debian package (added amd64 build matrix row for the humble/jammy ABI).
+
 0.5.3 (2026-05-29)
 -------------------
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robotops_msgs</name>
-  <version>0.5.3</version>
+  <version>0.5.4</version>
   <description>ROS2 message definitions for RobotOps distributed tracing</description>
   <maintainer email="support@robotops.dev">RobotOps Team</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
## ROB-402: publish Humble/amd64 ROS dependency debs

Adds an `amd64` row to the existing Humble/jammy build matrix in `release.yml`, mirroring the existing humble/arm64 row, so `ros-humble-robotops-msgs` is published for amd64 (jammy ABI).

- `release.yml`: new matrix entry `arch: amd64 / runner: ubuntu-22.04 / ros_distro: humble / os_version: jammy`
- `package.xml`: version 0.5.3 → 0.5.4
- `CHANGELOG.rst`: 0.5.4 entry

First of three repos in the dependency chain (msgs → config → rmw).