### PR TITLE
release: bump robotops_msgs 0.6.0 (TraceEvent.direction needs a version, ROB-406)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robotops_msgs</name>
-  <version>0.5.4</version>
+  <version>0.6.0</version>
   <description>ROS2 message definitions for RobotOps distributed tracing</description>
   <maintainer email="support@robotops.dev">RobotOps Team</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
0.5.4 was already prod-released (2026-06-17) WITHOUT the WS-1 `direction` field, so the field needs a fresh version. Bumps to 0.6.0 → will be promoted to main + prod-released so robot_agent can resolve it. Epic ROB-405.

https://claude.ai/code/session_01CTGD6b76YRbYHTiahBCHv4