### PR TITLE
docs(changelog): 0.6.0 entry (ROB-406)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.6.0 (2026-06-23)
+-------------------
+
+* Added ``direction`` field (UNSPECIFIED/PRODUCER/CONSUMER) to TraceEvent so robot_agent can distinguish the producer vs consumer side of service/action RPC events and stitch them into one trace (ROB-406).
+
 0.5.4 (2026-06-16)
 -------------------
 


### PR DESCRIPTION
Adds the CHANGELOG.rst 0.6.0 entry required by check-version / the release pipeline (the version bump #49 lacked it). Epic ROB-405.

https://claude.ai/code/session_01CTGD6b76YRbYHTiahBCHv4