### PR TITLE
release: promote robotops_msgs 0.6.0 to main (TraceEvent.direction, ROB-406)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.6.0 (2026-06-23)
+-------------------
+
+* Added ``direction`` field (UNSPECIFIED/PRODUCER/CONSUMER) to TraceEvent so robot_agent can distinguish the producer vs consumer side of service/action RPC events and stitch them into one trace (ROB-406).
+
 0.5.4 (2026-06-16)
 -------------------
 

--- a/msg/TraceEvent.msg
+++ b/msg/TraceEvent.msg
@@ -52,3 +52,21 @@ uint8 correlation_method
 uint8 CORRELATION_FASTDDS_SEQUENCE = 1    # Deterministic (related_sample_identity)
 uint8 CORRELATION_FALLBACK_HASH = 2       # Probabilistic (GID + timestamp + hash)
 uint8 CORRELATION_FALLBACK_TIMESTAMP = 3  # Probabilistic (GID + timestamp only)
+
+# Producer-vs-consumer direction for request/response-style events (ROB-406).
+#
+# For pub/sub the event_type already encodes direction (PUBLISH_* = producer,
+# TAKE_* = consumer). For services and actions, however, the SAME event_type is
+# emitted on both ends of an RPC: a client sending a request and a service
+# server taking that request both emit EVENT_SERVICE_REQUEST. The
+# CorrelationEngine in robot_agent needs to know which side SEEDS the
+# correlation window (the producer / client-send) and which side CORRELATES
+# against it (the consumer / server-take). This field carries that distinction.
+#
+# DIRECTION_UNSPECIFIED (0) is the default and preserves the historical meaning
+# for pub/sub events, where direction is already implicit in event_type. Old
+# producers that never set this field deserialize as UNSPECIFIED.
+uint8 direction
+uint8 DIRECTION_UNSPECIFIED = 0   # Direction implicit in event_type (pub/sub) or unknown
+uint8 DIRECTION_PRODUCER = 1      # This end SEEDS correlation (client send_request / send_response)
+uint8 DIRECTION_CONSUMER = 2      # This end CORRELATES (service take_request / client take_response)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robotops_msgs</name>
-  <version>0.5.4</version>
+  <version>0.6.0</version>
   <description>ROS2 message definitions for RobotOps distributed tracing</description>
   <maintainer email="support@robotops.dev">RobotOps Team</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
Promotes 0.6.0 (new TraceEvent.direction field + changelog) to main for a prod release, so robot_agent can resolve it from codeartifact-prod. Epic ROB-405.

https://claude.ai/code/session_01CTGD6b76YRbYHTiahBCHv4