### PR TITLE
ci: require a version bump when msg/srv/action interfaces change (ROB-405)

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -69,3 +69,65 @@ jobs:
             echo "::error::tools/generate-sdk.sh not found"
             exit 1
           fi
+
+  # Guard against shipping an interface change (msg/srv/action) under an
+  # already-released version. A new field once landed in msg/TraceEvent.msg
+  # without bumping <version> in package.xml, so it shipped under the already-
+  # released 0.5.4 and collided downstream. This job requires a real version
+  # bump whenever an interface file changes.
+  version-bump-required:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need history to diff against the base branch
+
+      - name: Require version bump when interfaces change
+        run: |
+          # Interface files whose change requires a version bump
+          CHANGED_FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+          echo ""
+
+          # Detect whether any interface file changed
+          CHANGED_INTERFACE=""
+          for file in $CHANGED_FILES; do
+            case "$file" in
+              msg/*.msg|srv/*.srv|action/*.action)
+                CHANGED_INTERFACE="$file"
+                echo "Interface file changed: $file"
+                ;;
+            esac
+          done
+
+          if [ -z "$CHANGED_INTERFACE" ]; then
+            echo "No interface (msg/srv/action) files changed - version bump not required"
+            exit 0
+          fi
+
+          echo ""
+          echo "Interface files changed - verifying package.xml <version> was bumped..."
+
+          # Extract <version> from base branch and head
+          OLD_VERSION=$(git show "origin/${{ github.base_ref }}:package.xml" \
+            | grep -oP '(?<=<version>)[^<]+' || echo "")
+          NEW_VERSION=$(grep -oP '(?<=<version>)[^<]+' package.xml || echo "")
+
+          echo "Base version: ${OLD_VERSION:-<none>}"
+          echo "Head version: ${NEW_VERSION:-<none>}"
+
+          if [ -z "$NEW_VERSION" ]; then
+            echo "::error::Could not read <version> from package.xml"
+            exit 1
+          fi
+
+          if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+            echo "::error::${CHANGED_INTERFACE} changed but package.xml version was not bumped (still ${NEW_VERSION}) — bump <version> in package.xml and add a CHANGELOG.rst entry"
+            exit 1
+          fi
+
+          echo "Version bumped: ${OLD_VERSION:-<none>} -> ${NEW_VERSION}"


### PR DESCRIPTION
## What

Adds a `version-bump-required` job to the existing **Version Check** workflow (`.github/workflows/version-check.yml`). On `pull_request`, it fails the PR if any interface file changed without a real bump of `<version>` in `package.xml` vs the base branch.

Interface files guarded:
- `msg/*.msg`
- `srv/*.srv` (future-proofing — none exist yet)
- `action/*.action` (future-proofing — none exist yet)

## Why

This prevents the schema-change-without-version-bump bug that caused major release pain: a new field was added to `msg/TraceEvent.msg` **without** bumping the version, so it shipped under the already-released **0.5.4** and collided downstream.

The existing `check-version` job validates that the *current* `package.xml` version is valid semver and has a `CHANGELOG.rst` entry — but it never checks that the version actually *changed* when an interface did. That gap is exactly what this job closes.

## How it works

1. Checks out with `fetch-depth: 0` so it can diff against the base branch.
2. Computes changed files via `git diff --name-only origin/${{ github.base_ref }}...HEAD`.
3. If no `msg/srv/action` file changed → passes (no bump required).
4. Otherwise compares the base-branch `<version>` (`git show origin/${{ github.base_ref }}:package.xml`) to the head `<version>`; if they're equal it fails with an actionable error:

   > `msg/TraceEvent.msg changed but package.xml version was not bumped (still 0.6.0) — bump <version> in package.xml and add a CHANGELOG.rst entry`

## Scope

- New **job** added to the existing version-check workflow (kept the simple `check-version` job untouched since it doesn't need git history).
- **Not** wired into branch protection / required status checks — the team can promote it to required later.
- YAML validated with `python -c "import yaml; yaml.safe_load(...)"` (parses cleanly; jobs: `check-version`, `version-bump-required`).

https://claude.ai/code/session_01CTGD6b76YRbYHTiahBCHv4